### PR TITLE
refactor - rename operator `states.select` to `states.convert`

### DIFF
--- a/lib/dart_scope.dart
+++ b/lib/dart_scope.dart
@@ -1,3 +1,4 @@
+library dart_scope;
 
 export 'src/dart_observable/dart_observable.dart'
   show

--- a/lib/src/dart_observable/states/states.dart
+++ b/lib/src/dart_observable/states/states.dart
@@ -75,7 +75,7 @@ extension StatesX<T> on States<T> {
       .asStates();
   }
 
-  States<R> select<R>(
+  States<R> convert<R>(
     R Function(T) convert, {
     Equals<R>? equals,
   }) {

--- a/lib/src/dart_scope/configurables/computed.dart
+++ b/lib/src/dart_scope/configurables/computed.dart
@@ -80,7 +80,7 @@ Equal<States<R>> _superEqual<T, R>(
 ) {
   return (scope) => scope
     .get<States<T>>(name: statesName)
-    .select<R>(
+    .convert<R>(
       (it) => compute(scope, it),
       equals: equals,
     );

--- a/test/dart_observable/dart_observable_test.dart
+++ b/test/dart_observable/dart_observable_test.dart
@@ -8,7 +8,7 @@ import 'states/states_distinct_test.dart' as states_distinct_test;
 import 'states/states_first_test.dart' as states_first_test;
 import 'states/states_from_test.dart' as states_from_test;
 import 'states/states_map_test.dart' as states_map_test;
-import 'states/states_select_test.dart' as states_select_test;
+import 'states/states_convert_test.dart' as states_convert_test;
 import 'states/states_skip_test.dart' as states_skip_test;
 import 'observables/observable_cast_test.dart' as observable_cast_test;
 import 'observables/observable_combine_test.dart' as observable_combine_test;
@@ -38,7 +38,7 @@ void main() {
   states_first_test.main();
   states_from_test.main();
   states_map_test.main();
-  states_select_test.main();
+  states_convert_test.main();
   states_skip_test.main();
   observable_cast_test.main();
   observable_combine_test.main();

--- a/test/dart_observable/states/states_convert_test.dart
+++ b/test/dart_observable/states/states_convert_test.dart
@@ -6,7 +6,7 @@ import '../shared/states_tester.dart';
 
 void main() {
   
-  test('`states.select` default equals', () {
+  test('`states.convert` default equals', () {
 
     final states = States<String>((setState) {
       setState('a');
@@ -16,11 +16,11 @@ void main() {
       return Disposable.empty;
     });
 
-    final select = states
-      .select((it) => '1$it');
+    final convert = states
+      .convert((it) => '1$it');
 
     final tester = StatesTester(
-      select,
+      convert,
     );
 
     expect(tester.recorded, <String>[]);
@@ -34,7 +34,7 @@ void main() {
 
   });
 
-  test('`states.select` custom equals', () {
+  test('`states.convert` custom equals', () {
 
     final states = States<String>((setState) {
       setState('a');
@@ -44,14 +44,14 @@ void main() {
       return Disposable.empty;
     });
 
-    final select = states
-      .select<String>(
+    final convert = states
+      .convert<String>(
         (it) => '1$it',
         equals: (it1, it2) => it1.length == it2.length,
       );
 
     final tester = StatesTester(
-      select,
+      convert,
     );
 
     expect(tester.recorded, <String>[]);


### PR DESCRIPTION
refactor - rename operator `states.select` to `states.convert`