### PR TITLE
refactor - rename `Observation` field `onData` to `emit`

### DIFF
--- a/lib/src/dart_observable/observables/observable_combine.dart
+++ b/lib/src/dart_observable/observables/observable_combine.dart
@@ -26,7 +26,7 @@ class ObservableCombine<T, R> implements Observable<R> {
     return _Observation<T, R>(
       observables: _observables,
       combiner: _combiner,
-      onData: onData,
+      emit: onData,
     );
   }
 }
@@ -77,10 +77,10 @@ class _Observation<T, R> extends Observation<R> {
   _Observation({
     required List<Observable<T>> observables,
     required R Function(List<T> items) combiner,
-    required OnData<R> onData,
+    required OnData<R> emit,
   }): _observables = observables,
     _combiner = combiner, 
-    super(onData: onData);
+    super(emit: emit);
 
   final List<Observable<T>> _observables;
   final R Function(List<T> items) _combiner;
@@ -117,7 +117,7 @@ class _Observation<T, R> extends Observation<R> {
       if (_emitted.length == _observablesLength) {
         final items = List<T>.from(_latests, growable: false);
         final combinedItem = _combiner(items);
-        onData(combinedItem);
+        emit(combinedItem);
       }
     };
   }

--- a/lib/src/dart_observable/observables/observation.dart
+++ b/lib/src/dart_observable/observables/observation.dart
@@ -8,13 +8,13 @@ import '../observers/observer.dart';
 abstract class Observation<T> implements Disposable {
 
   Observation({
-    required this.onData,
+    required this.emit,
   }) {
     init();
   }
 
   @internal
-  final OnData<T> onData;
+  final OnData<T> emit;
 
   @internal
   @mustCallSuper


### PR DESCRIPTION
When `Observation` subclass implements `Observer` interface, there is a confict with `observation.onData` field and `observer.onData` method:

```dart
/// Error: 
/// 'onData' is inherited as a getter (from 'Observation') and also a method (from 'Observer').
/// Try adjusting the supertypes of this class to remove the inconsistency.
///
class MyObservation<T> extends Observation<T> implements Observer<T> {
  ... 
}
```
To resolve this conflict, trying to rename `Observation` field `onData` to `emit`.

Relate #158 
