### PR TITLE
refactor - prefer `source` over `observable` to name input observable

### DIFF
--- a/lib/src/dart_observable/observables/observable.dart
+++ b/lib/src/dart_observable/observables/observable.dart
@@ -114,10 +114,10 @@ abstract class Observable<T> {
   /// 
   /// Modified from: https://reactivex.io/documentation/operators/combinelatest.html
   static Observable<R> combine<T, R>({
-    required List<Observable<T>> observables,
+    required List<Observable<T>> sources,
     required R Function(List<T> items) combiner,
   }) => ObservableCombine(
-    observables: observables,
+    sources: sources,
     combiner: combiner,
   );
 
@@ -129,12 +129,12 @@ abstract class Observable<T> {
   /// 
   /// Modified from: https://reactivex.io/documentation/operators/combinelatest.html
   static Observable<R> combine2<T1, T2, R>({
-    required Observable<T1> observable1,
-    required Observable<T2> observable2,
+    required Observable<T1> source1,
+    required Observable<T2> source2,
     required R Function(T1, T2) combiner,
   }) => CombineObservable2(
-    observable1: observable1,
-    observable2: observable2,
+    source1: source1,
+    source2: source2,
     combiner: combiner,
   );
 
@@ -146,14 +146,14 @@ abstract class Observable<T> {
   /// 
   /// Modified from: https://reactivex.io/documentation/operators/combinelatest.html
   static Observable<R> combine3<T1, T2, T3, R>({
-    required Observable<T1> observable1,
-    required Observable<T2> observable2,
-    required Observable<T3> observable3,
+    required Observable<T1> source1,
+    required Observable<T2> source2,
+    required Observable<T3> source3,
     required R Function(T1, T2, T3) combiner,
   }) => CombineObservable3(
-    observable1: observable1,
-    observable2: observable2,
-    observable3: observable3,
+    source1: source1,
+    source2: source2,
+    source3: source3,
     combiner: combiner,
   );
 }
@@ -174,7 +174,7 @@ extension ObservableX<T> on Observable<T> {
   Observable<R> map<R>(R Function(T) convert) {
     return ObservableMap<T, R>(
       convert: convert,
-      observable: this,
+      source: this,
     );
   }
 
@@ -188,7 +188,7 @@ extension ObservableX<T> on Observable<T> {
   Observable<T> where(bool Function(T) test) {
     return ObservableWhere<T>(
       test: test,
-      observable: this,
+      source: this,
     );
   }
 
@@ -196,7 +196,7 @@ extension ObservableX<T> on Observable<T> {
   /// by casting each item as `R`.
   Observable<R> cast<R>() {
     return ObservableCast<T, R>(
-      observable: this,
+      source: this,
     );
   }
 
@@ -207,7 +207,7 @@ extension ObservableX<T> on Observable<T> {
   Observable<T> distinct([Equals<T>? equals]) {
     return ObservableDistinct<T>(
       equals: equals,
-      observable: this,
+      source: this,
     );
   }
 
@@ -232,7 +232,7 @@ extension ObservableX<T> on Observable<T> {
   Observable<T> skip(int n) {
     return ObservableSkip(
       n: n,
-      observable: this,
+      source: this,
     );
   }
 
@@ -249,7 +249,7 @@ extension ObservableX<T> on Observable<T> {
   }) {
     return ObservableMulticast<T>(
       createSubject: createSubject,
-      observable: this,
+      source: this,
     );
   }
 

--- a/lib/src/dart_observable/observables/observable_cast.dart
+++ b/lib/src/dart_observable/observables/observable_cast.dart
@@ -9,14 +9,14 @@ import 'observable.dart';
 class ObservableCast<T, R> implements Observable<R> {
 
   const ObservableCast({
-    required Observable<T> observable,
-  }): _observable = observable;
+    required Observable<T> source,
+  }): _source = source;
 
-  final Observable<T> _observable;
+  final Observable<T> _source;
 
   @override
   Disposable observe(OnData<R> onData) {
-    return _observable.observe((data) {
+    return _source.observe((data) {
       onData(data as R);
     });
   }

--- a/lib/src/dart_observable/observables/observable_combine.dart
+++ b/lib/src/dart_observable/observables/observable_combine.dart
@@ -10,21 +10,21 @@ import 'observation.dart';
 class ObservableCombine<T, R> implements Observable<R> {
 
   const ObservableCombine({
-    required List<Observable<T>> observables,
+    required List<Observable<T>> sources,
     required R Function(List<T> items) combiner,
-  }): _observables = observables,
+  }): _sources = sources,
     _combiner = combiner;
 
-  final List<Observable<T>> _observables;
+  final List<Observable<T>> _sources;
   final R Function(List<T> items) _combiner;
 
   @override
   Disposable observe(OnData<R> onData) {
-    if (_observables.isEmpty) {
+    if (_sources.isEmpty) {
       return Disposable.empty;
     }
     return _Observation<T, R>(
-      observables: _observables,
+      sources: _sources,
       combiner: _combiner,
       emit: onData,
     );
@@ -35,13 +35,13 @@ class ObservableCombine<T, R> implements Observable<R> {
 class CombineObservable2<T1, T2, R> extends ObservableCombine<Object?, R> {
 
   CombineObservable2({
-    required Observable<T1> observable1,
-    required Observable<T2> observable2,
+    required Observable<T1> source1,
+    required Observable<T2> source2,
     required R Function(T1, T2) combiner,
   }): super(
-    observables: [
-      observable1.cast<Object?>(),
-      observable2.cast<Object?>(),
+    sources: [
+      source1.cast<Object?>(),
+      source2.cast<Object?>(),
     ],
     combiner: (items) => combiner(
       items[0] as T1,
@@ -54,15 +54,15 @@ class CombineObservable2<T1, T2, R> extends ObservableCombine<Object?, R> {
 class CombineObservable3<T1, T2, T3, R> extends ObservableCombine<Object?, R> {
 
   CombineObservable3({
-    required Observable<T1> observable1,
-    required Observable<T2> observable2,
-    required Observable<T3> observable3,
+    required Observable<T1> source1,
+    required Observable<T2> source2,
+    required Observable<T3> source3,
     required R Function(T1, T2, T3) combiner,
   }): super(
-    observables: [
-      observable1.cast<Object?>(),
-      observable2.cast<Object?>(),
-      observable3.cast<Object?>(),
+    sources: [
+      source1.cast<Object?>(),
+      source2.cast<Object?>(),
+      source3.cast<Object?>(),
     ],
     combiner: (items) => combiner(
       items[0] as T1,
@@ -75,32 +75,32 @@ class CombineObservable3<T1, T2, T3, R> extends ObservableCombine<Object?, R> {
 class _Observation<T, R> extends Observation<R> {
 
   _Observation({
-    required List<Observable<T>> observables,
+    required List<Observable<T>> sources,
     required R Function(List<T> items) combiner,
     required super.emit,
-  }): _observables = observables,
+  }): _sources = sources,
     _combiner = combiner;
 
-  final List<Observable<T>> _observables;
+  final List<Observable<T>> _sources;
   final R Function(List<T> items) _combiner;
 
-  late final int _observablesLength;
+  late final int _sourcesLength;
   late final Set<int> _emitted;
   late final List<T?> _latestItems;
   late final List<Disposable> _sourceObservations;
 
   @override
   void init() {
-    _observablesLength = _observables.length;
+    _sourcesLength = _sources.length;
     _emitted = <int>{};
-    _latestItems = List<T?>.filled(_observablesLength, null);
+    _latestItems = List<T?>.filled(_sourcesLength, null);
     _sourceObservations = Iterable<Disposable>
-      .generate(_observablesLength, _observeIndexed)
+      .generate(_sourcesLength, _observeIndexed)
       .toList();
   }
 
   Disposable _observeIndexed(int index) {
-    return _observables[index]
+    return _sources[index]
       .observe(_onDataIndexed(index));
   }
 
@@ -110,7 +110,7 @@ class _Observation<T, R> extends Observation<R> {
         _emitted.add(index);
       }
       _latestItems[index] = data;
-      if (_emitted.length == _observablesLength) {
+      if (_emitted.length == _sourcesLength) {
         final items = List<T>.from(_latestItems, growable: false);
         final combinedItem = _combiner(items);
         emit(combinedItem);

--- a/lib/src/dart_observable/observables/observable_distinct.dart
+++ b/lib/src/dart_observable/observables/observable_distinct.dart
@@ -12,18 +12,18 @@ import 'observation.dart';
 class ObservableDistinct<T> implements Observable<T> {
   const ObservableDistinct({
     required Equals<T>? equals,
-    required Observable<T> observable,
+    required Observable<T> source,
   }): _equals = equals ?? defaultEquals,
-    _observable = observable;
+    _source = source;
 
   final Equals<T> _equals;
-  final Observable<T> _observable;
+  final Observable<T> _source;
 
   @override
   Disposable observe(OnData<T> onData) {
     return _Observation<T>(
       equals: _equals,
-      observable: _observable,
+      source: _source,
       emit: onData,
     );
   }
@@ -33,20 +33,20 @@ class _Observation<T> extends Observation<T> implements Observer<T> {
 
   _Observation({
     required Equals<T> equals,
-    required Observable<T> observable,
+    required Observable<T> source,
     required super.emit,
   }): _equals = equals,
-    _observable = observable;
+    _source = source;
 
   final Equals<T> _equals;
-  final Observable<T> _observable;
+  final Observable<T> _source;
 
   Value<T>? _oldData;
   late final Disposable _sourceObservation;
 
   @override
   void init() {
-    _sourceObservation = _observable.observe(onData);
+    _sourceObservation = _source.observe(onData);
   }
 
   @override

--- a/lib/src/dart_observable/observables/observable_map.dart
+++ b/lib/src/dart_observable/observables/observable_map.dart
@@ -10,16 +10,16 @@ class ObservableMap<T, R> implements Observable<R> {
   
   const ObservableMap({
     required R Function(T) convert,
-    required Observable<T> observable,
+    required Observable<T> source,
   }): _convert = convert,
-    _observable = observable;
+    _source = source;
 
   final R Function(T) _convert;
-  final Observable<T> _observable;
+  final Observable<T> _source;
 
   @override
   Disposable observe(OnData<R> onData) {
-    return _observable.observe((data) {
+    return _source.observe((data) {
       final result = _convert(data);
       onData(result);
     });

--- a/lib/src/dart_observable/observables/observable_multicast.dart
+++ b/lib/src/dart_observable/observables/observable_multicast.dart
@@ -13,13 +13,13 @@ class ObservableMulticast<T> implements Observable<T> {
 
   ObservableMulticast({
     Subject<T> Function()? createSubject,
-    required Observable<T> observable,
+    required Observable<T> source,
   }): _createSubject = createSubject ?? _defaultCreateSubject,
-    _observable = observable,
+    _source = source,
     _shared = _SharedBetweenObservations<T>();
 
   final Subject<T> Function() _createSubject;
-  final Observable<T> _observable;
+  final Observable<T> _source;
 
   final _SharedBetweenObservations<T> _shared;
 
@@ -27,7 +27,7 @@ class ObservableMulticast<T> implements Observable<T> {
   Disposable observe(OnData<T> onData) {
     return _Observation<T>(
       createSubject: _createSubject,
-      observable: _observable,
+      source: _source,
       shared: _shared,
       emit: onData,
     );
@@ -48,15 +48,15 @@ class _Observation<T> extends Observation<T> {
 
   _Observation({
     required Subject<T> Function() createSubject,
-    required Observable<T> observable,
+    required Observable<T> source,
     required _SharedBetweenObservations<T> shared,
     required super.emit,
   }): _createSubject = createSubject,
-    _observable = observable,
+    _source = source,
     _shared = shared;
 
   final Subject<T> Function() _createSubject;
-  final Observable<T> _observable;
+  final Observable<T> _source;
 
   final _SharedBetweenObservations<T> _shared;
 
@@ -69,7 +69,7 @@ class _Observation<T> extends Observation<T> {
     _subjectObservation = subject.observe(emit);
     _shared.observersCount += 1;
     if (_shared.observersCount == 1) {
-      _shared.observation = _observable.observe(subject.onData);
+      _shared.observation = _source.observe(subject.onData);
     }
   }
 

--- a/lib/src/dart_observable/observables/observable_skip.dart
+++ b/lib/src/dart_observable/observables/observable_skip.dart
@@ -11,18 +11,18 @@ class ObservableSkip<T> implements Observable<T> {
 
   const ObservableSkip({
     required int n,
-    required Observable<T> observable,
+    required Observable<T> source,
   }): _n = n,
-    _observable = observable;
+    _source = source;
 
   final int _n;
-  final Observable<T> _observable;
+  final Observable<T> _source;
 
   @override
   Disposable observe(OnData<T> onData) {
     return _Observation<T>(
       n: _n,
-      observable: _observable,
+      source: _source,
       emit: onData,
     );
   }
@@ -32,19 +32,19 @@ class _Observation<T> extends Observation<T> implements Observer<T> {
 
   _Observation({
     required int n,
-    required Observable<T> observable,
+    required Observable<T> source,
     required super.emit,
   }): _shouldSkip = n,
-    _observable = observable;
+    _source = source;
 
-  final Observable<T> _observable;
+  final Observable<T> _source;
 
   int _shouldSkip;
   late final Disposable _sourceObservation;
 
   @override
   void init() {
-    _sourceObservation = _observable.observe(onData);
+    _sourceObservation = _source.observe(onData);
   }
 
   @override

--- a/lib/src/dart_observable/observables/observable_where.dart
+++ b/lib/src/dart_observable/observables/observable_where.dart
@@ -10,12 +10,12 @@ class ObservableWhere<T> implements Observable<T> {
 
   const ObservableWhere({
     required bool Function(T) test,
-    required Observable<T> observable,
+    required Observable<T> source,
   }): _test = test,
-    _observable = observable;
+    _source = source;
 
   final bool Function(T) _test;
-  final Observable<T> _observable;
+  final Observable<T> _source;
 
   @override
   Disposable observe(OnData<T> onData) {
@@ -24,6 +24,6 @@ class ObservableWhere<T> implements Observable<T> {
         onData(data);
       }
     }
-    return _observable.observe(newOnData);
+    return _source.observe(newOnData);
   }
 }

--- a/lib/src/dart_observable/states/states.dart
+++ b/lib/src/dart_observable/states/states.dart
@@ -65,7 +65,7 @@ class States<T> {
     required List<States<T>> states,
     required R Function(List<T> items) combiner,
   }) => Observable.combine<T, R>(
-    observables: states
+    sources: states
       .map((states) => states.observable)
       .toList(),
     combiner: combiner,
@@ -83,8 +83,8 @@ class States<T> {
     required States<T2> states2,
     required R Function(T1, T2) combiner,
   }) => Observable.combine2<T1, T2, R>(
-    observable1: states1.observable,
-    observable2: states2.observable,
+    source1: states1.observable,
+    source2: states2.observable,
     combiner: combiner,
   ).asStates();
 
@@ -101,9 +101,9 @@ class States<T> {
     required States<T3> states3,
     required R Function(T1, T2, T3) combiner,
   }) => Observable.combine3<T1, T2, T3, R>(
-    observable1: states1.observable,
-    observable2: states2.observable,
-    observable3: states3.observable,
+    source1: states1.observable,
+    source2: states2.observable,
+    source3: states3.observable,
     combiner: combiner,
   ).asStates();
 

--- a/test/dart_observable/observables/observable_combine_test.g.dart
+++ b/test/dart_observable/observables/observable_combine_test.g.dart
@@ -19,7 +19,7 @@ void _main() {
     });
 
     final combine = Observable.combine<String, String>(
-      observables: [
+      sources: [
         observable1,
         observable2,
       ],
@@ -53,8 +53,8 @@ void _main() {
     });
 
     final combine = Observable.combine2<String, String, String>(
-      observable1: observable1,
-      observable2: observable2,
+      source1: observable1,
+      source2: observable2,
       combiner: (it1, it2) => '$it1|$it2',
     );
 
@@ -90,9 +90,9 @@ void _main() {
     });
 
     final combine = Observable.combine3<String, String, String, String>(
-      observable1: observable1,
-      observable2: observable2,
-      observable3: observable3,
+      source1: observable1,
+      source2: observable2,
+      source3: observable3,
       combiner: (it1, it2, it3) => '$it1|$it2|$it3',
     );
 
@@ -125,7 +125,7 @@ void _main() {
     });
 
     final combine = Observable.combine<String, String>(
-      observables: [
+      sources: [
         observable1,
         observable2,
       ],
@@ -161,8 +161,8 @@ void _main() {
     });
 
     final combine = Observable.combine2<String, String, String>(
-      observable1: observable1,
-      observable2: observable2,
+      source1: observable1,
+      source2: observable2,
       combiner: (it1, it2) => '$it1|$it2',
     );
 
@@ -200,9 +200,9 @@ void _main() {
     });
 
     final combine = Observable.combine3<String, String, String, String>(
-      observable1: observable1,
-      observable2: observable2,
-      observable3: observable3,
+      source1: observable1,
+      source2: observable2,
+      source3: observable3,
       combiner: (it1, it2, it3) => '$it1|$it2|$it3',
     );
 
@@ -238,7 +238,7 @@ void _main() {
     });
 
     final combine = Observable.combine<String, String>(
-      observables: [
+      sources: [
         observable1,
         observable2,
       ],
@@ -271,8 +271,8 @@ void _main() {
     });
 
     final combine = Observable.combine2<String, String, String>(
-      observable1: observable1,
-      observable2: observable2,
+      source1: observable1,
+      source2: observable2,
       combiner: (it1, it2) => '$it1|$it2',
     );
 
@@ -308,9 +308,9 @@ void _main() {
     });
 
     final combine = Observable.combine3<String, String, String, String>(
-      observable1: observable1,
-      observable2: observable2,
-      observable3: observable3,
+      source1: observable1,
+      source2: observable2,
+      source3: observable3,
       combiner: (it1, it2, it3) => '$it1|$it2|$it3',
     );
 
@@ -337,7 +337,7 @@ void _main() {
     });
 
     final combine = Observable.combine<String, String>(
-      observables: [
+      sources: [
         observable1,
         observable2,
       ],
@@ -373,8 +373,8 @@ void _main() {
     });
 
     final combine = Observable.combine2<String, String, String>(
-      observable1: observable1,
-      observable2: observable2,
+      source1: observable1,
+      source2: observable2,
       combiner: (it1, it2) => '$it1|$it2',
     );
 
@@ -412,9 +412,9 @@ void _main() {
     });
 
     final combine = Observable.combine3<String, String, String, String>(
-      observable1: observable1,
-      observable2: observable2,
-      observable3: observable3,
+      source1: observable1,
+      source2: observable2,
+      source3: observable3,
       combiner: (it1, it2, it3) => '$it1|$it2|$it3',
     );
 

--- a/test/test_gen/combine_test/shared/codes.dart
+++ b/test/test_gen/combine_test/shared/codes.dart
@@ -19,8 +19,8 @@ String statesCombine(int? number) {
 String _combine(bool isObservable, int? number) {
   final type = isObservable ? 'Observable' : 'States';
   final name = isObservable ? 'observable' : 'states';
-  final sources = isObservable ? 'observables' : 'states';
-  final source = isObservable ? 'observable' : 'states';
+  final sources = isObservable ? 'sources' : 'states';
+  final source = isObservable ? 'source' : 'states';
   if (number == null) {
     return '''
       final combine = $type.combine<String, String>(


### PR DESCRIPTION
refactor - prefer `source` over `observable` to name input observable