### PR TITLE
refactor - add `observation.configuration` field

### DIFF
--- a/lib/src/dart_observable/observables/observable.dart
+++ b/lib/src/dart_observable/observables/observable.dart
@@ -103,7 +103,7 @@ abstract class Observable<T> {
   /// ```
   /// 
   const factory Observable(
-    Observe<T> observe
+    Observe<T> inlineObserve
   ) = ObservableCreate;
   
   /// Combine multiple `Observable` into one `Observable`.

--- a/lib/src/dart_observable/observables/observable_create.dart
+++ b/lib/src/dart_observable/observables/observable_create.dart
@@ -9,34 +9,32 @@ import '../observers/observer.dart';
 @internal
 class ObservableCreate<T> implements Observable<T> {
 
-  const ObservableCreate(this._observe);
+  const ObservableCreate(this.inlineObserve);
 
-  final Observe<T> _observe;
+  final Observe<T> inlineObserve;
 
   @override
   Disposable observe(OnData<T> onData) {
     return _Observation<T>(
-      observe: _observe,
+      configuration: this,
       emit: onData,
     );
   }
 }
 
-class _Observation<T> extends Observation<T> implements Observer<T> {
+class _Observation<T> extends Observation<ObservableCreate<T>, T> implements Observer<T> {
 
   _Observation({
-    required Observe<T> observe,
+    required super.configuration, 
     required super.emit,
-  }): _observe = observe;
-
-  final Observe<T> _observe;
+  });
 
   bool _disposed = false;
   late final Disposable _sourceObservation;
 
   @override
   void init() {
-    _sourceObservation = _observe(onData);
+    _sourceObservation = configuration.inlineObserve(onData);
   }
 
   @override

--- a/lib/src/dart_observable/observables/observable_distinct.dart
+++ b/lib/src/dart_observable/observables/observable_distinct.dart
@@ -11,42 +11,36 @@ import 'observation.dart';
 @internal
 class ObservableDistinct<T> implements Observable<T> {
   const ObservableDistinct({
-    required Equals<T>? equals,
-    required Observable<T> source,
-  }): _equals = equals ?? defaultEquals,
-    _source = source;
+    required this.equals,
+    required this.source,
+  });
 
-  final Equals<T> _equals;
-  final Observable<T> _source;
+  final Equals<T>? equals;
+  final Observable<T> source;
 
   @override
   Disposable observe(OnData<T> onData) {
     return _Observation<T>(
-      equals: _equals,
-      source: _source,
+      configuration: this,
       emit: onData,
     );
   }
 }
 
-class _Observation<T> extends Observation<T> implements Observer<T> {
+class _Observation<T> extends Observation<ObservableDistinct<T>, T> implements Observer<T> {
 
   _Observation({
-    required Equals<T> equals,
-    required Observable<T> source,
+    required super.configuration, 
     required super.emit,
-  }): _equals = equals,
-    _source = source;
-
-  final Equals<T> _equals;
-  final Observable<T> _source;
+  });
 
   Value<T>? _oldData;
   late final Disposable _sourceObservation;
+  late final Equals<T> _equals = configuration.equals ?? defaultEquals;
 
   @override
   void init() {
-    _sourceObservation = _source.observe(onData);
+    _sourceObservation = configuration.source.observe(onData);
   }
 
   @override

--- a/lib/src/dart_observable/observables/observable_skip.dart
+++ b/lib/src/dart_observable/observables/observable_skip.dart
@@ -10,41 +10,36 @@ import '../observers/observer.dart';
 class ObservableSkip<T> implements Observable<T> {
 
   const ObservableSkip({
-    required int n,
-    required Observable<T> source,
-  }): _n = n,
-    _source = source;
+    required this.n,
+    required this.source,
+  });
 
-  final int _n;
-  final Observable<T> _source;
+  final int n;
+  final Observable<T> source;
 
   @override
   Disposable observe(OnData<T> onData) {
     return _Observation<T>(
-      n: _n,
-      source: _source,
+      configuration: this,
       emit: onData,
     );
   }
 }
 
-class _Observation<T> extends Observation<T> implements Observer<T> {
+class _Observation<T> extends Observation<ObservableSkip<T>, T> implements Observer<T> {
 
   _Observation({
-    required int n,
-    required Observable<T> source,
-    required super.emit,
-  }): _shouldSkip = n,
-    _source = source;
+    required super.configuration, 
+    required super.emit
+  });
 
-  final Observable<T> _source;
-
-  int _shouldSkip;
+  late int _shouldSkip;
   late final Disposable _sourceObservation;
 
   @override
   void init() {
-    _sourceObservation = _source.observe(onData);
+    _shouldSkip = configuration.n;
+    _sourceObservation = configuration.source.observe(onData);
   }
 
   @override

--- a/lib/src/dart_observable/observables/observation.dart
+++ b/lib/src/dart_observable/observables/observation.dart
@@ -2,16 +2,21 @@
 import 'package:disposal/disposal.dart';
 import 'package:meta/meta.dart';
 
+import 'observable.dart';
 import '../observers/observer.dart';
 
 @internal
-abstract class Observation<T> implements Disposable {
+abstract class Observation<O extends Observable<T>, T> implements Disposable {
 
   Observation({
+    required this.configuration,
     required this.emit,
   }) {
     init();
   }
+
+  @internal
+  final O configuration;
 
   @internal
   final OnData<T> emit;


### PR DESCRIPTION
add `observation.configuration` field, it simpify implementation of observation.

### before

```dart
abstract class Observation<T> implements Disposable {

  Observation({
    required this.emit,
  }) {
    init();
  }

  final OnData<T> emit;

  void init();
}
```

### after

```dart
abstract class Observation<O extends Observable<T>, T> implements Disposable {

  Observation({
    required this.configuration,
    required this.emit,
  }) {
    init();
  }

  final O configuration;
  final OnData<T> emit;

  void init();
}
```

### before

```dart
class ObservableCreate<T> implements Observable<T> {

  const ObservableCreate(this._inlineObserve);

  final Observe<T> _inlineObserve;

  @override
  Disposable observe(OnData<T> onData) {
    return _Observation<T>(
      inlineObserve: _inlineObserve,
      emit: onData,
    );
  }
}

class _Observation<T> extends Observation<T> implements Observer<T> {

  _Observation({
    required Observe<T> inlineObserve, 
    required super.emit,
  }): _inlineObserve = inlineObserve;
 
  final Observe<T> _inlineObserve;
  ...
}
```

### after

```dart
class ObservableCreate<T> implements Observable<T> {

  const ObservableCreate(this.inlineObserve);

  final Observe<T> inlineObserve;

  @override
  Disposable observe(OnData<T> onData) {
    return _Observation<T>(
      configuration: this,
      emit: onData,
    );
  }
}

class _Observation<T> extends Observation<ObservableCreate<T>, T> implements Observer<T> {

  _Observation({
    required super.configuration, 
    required super.emit,
  });
 
  ...
}
```

It reduces passing down batch parameters manually.