### PR TITLE
refactor - introduce observable `PipeObservable`

### DIFF
--- a/lib/dart_scope.dart
+++ b/lib/dart_scope.dart
@@ -13,6 +13,7 @@ export 'src/dart_observable/dart_observable.dart'
     StatesActivated,
     ObservableAsStatesX,
     LatestStateNotReplayError,
+    PipeObservable,
     Observe,
     Observable,
     ObservableX,

--- a/lib/src/dart_observable/dart_observable.dart
+++ b/lib/src/dart_observable/dart_observable.dart
@@ -22,6 +22,9 @@ export 'states/observable_as_states_x.dart'
 export 'errors/latest_state_not_replay_error.dart'
   show
     LatestStateNotReplayError;
+export 'observables/base_observable.dart'
+  show
+    PipeObservable;
 export 'observables/observable.dart'
   show
     Observe,

--- a/lib/src/dart_observable/observables/base_observable.dart
+++ b/lib/src/dart_observable/observables/base_observable.dart
@@ -1,0 +1,36 @@
+
+import 'observable.dart';
+
+/// `PipeObservable` transform an input observable (the source) 
+/// to an output observable (itself).
+/// 
+/// Example:
+/// 
+/// ```dart
+/// class ObservableMap<T, R> extends PipeObservable<T, R> {
+///   
+///   const ObservableMap({
+///     required this.convert,
+///     required super.source,
+///   });
+/// 
+///   final R Function(T) convert;
+/// 
+///   @override
+///   Disposable observe(OnData<R> onData) { ... }
+/// }
+/// ```
+/// 
+/// `ObservableMap<T, R>` is a `PipeObservable`, since it transform
+/// an input `Observable<T>` to an output `Observable<R>`.
+/// 
+abstract class PipeObservable<T, R> implements Observable<R> {
+
+  /// Create a `PipeObservable` with input source.
+  const PipeObservable({
+    required this.source,
+  });
+
+  /// The input observable
+  final Observable<T> source;
+}

--- a/lib/src/dart_observable/observables/base_observable.dart
+++ b/lib/src/dart_observable/observables/base_observable.dart
@@ -4,6 +4,17 @@ import 'observable.dart';
 /// `PipeObservable` transform an input observable (the source) 
 /// to an output observable (itself).
 /// 
+/// ```dart
+/// abstract class PipeObservable<T, R> implements Observable<R> {
+/// 
+///   const PipeObservable({
+///     required this.source,
+///   });
+/// 
+///   final Observable<T> source;
+/// }
+/// ``` 
+/// 
 /// Example:
 /// 
 /// ```dart

--- a/lib/src/dart_observable/observables/base_observable.dart
+++ b/lib/src/dart_observable/observables/base_observable.dart
@@ -1,8 +1,11 @@
 
 import 'observable.dart';
 
-/// `PipeObservable` transform an input observable (the source) 
-/// to an output observable (itself).
+/// `PipeObservable` is a pipeline that transform an input observable
+/// to an output observable.
+/// 
+/// The input observable is the source that implements `Observable<T>`,
+/// and the output observable is itself that implements `Observable<R>`.
 /// 
 /// ```dart
 /// abstract class PipeObservable<T, R> implements Observable<R> {

--- a/lib/src/dart_observable/observables/observable_cast.dart
+++ b/lib/src/dart_observable/observables/observable_cast.dart
@@ -3,20 +3,18 @@ import 'package:meta/meta.dart';
 import 'package:disposal/disposal.dart';
 
 import '../observers/observer.dart';
-import 'observable.dart';
+import 'base_observable.dart';
 
 @internal
-class ObservableCast<T, R> implements Observable<R> {
+class ObservableCast<T, R> extends PipeObservable<T, R> {
 
   const ObservableCast({
-    required Observable<T> source,
-  }): _source = source;
-
-  final Observable<T> _source;
+    required super.source,
+  });
 
   @override
   Disposable observe(OnData<R> onData) {
-    return _source.observe((data) {
+    return source.observe((data) {
       onData(data as R);
     });
   }

--- a/lib/src/dart_observable/observables/observable_distinct.dart
+++ b/lib/src/dart_observable/observables/observable_distinct.dart
@@ -5,18 +5,18 @@ import 'package:typedef_equals/typedef_equals.dart';
 
 import '../../shared/value.dart';
 import '../observers/observer.dart';
-import 'observable.dart';
+import 'base_observable.dart';
 import 'observation.dart';
 
 @internal
-class ObservableDistinct<T> implements Observable<T> {
+class ObservableDistinct<T> extends PipeObservable<T, T> {
+  
   const ObservableDistinct({
     required this.equals,
-    required this.source,
+    required super.source,
   });
 
   final Equals<T>? equals;
-  final Observable<T> source;
 
   @override
   Disposable observe(OnData<T> onData) {

--- a/lib/src/dart_observable/observables/observable_map.dart
+++ b/lib/src/dart_observable/observables/observable_map.dart
@@ -2,24 +2,22 @@
 import 'package:meta/meta.dart';
 import 'package:disposal/disposal.dart';
 
-import 'observable.dart';
 import '../observers/observer.dart';
+import 'base_observable.dart';
 
 @internal
-class ObservableMap<T, R> implements Observable<R> {
+class ObservableMap<T, R> extends PipeObservable<T, R> {
   
   const ObservableMap({
     required R Function(T) convert,
-    required Observable<T> source,
-  }): _convert = convert,
-    _source = source;
+    required super.source,
+  }): _convert = convert;
 
   final R Function(T) _convert;
-  final Observable<T> _source;
 
   @override
   Disposable observe(OnData<R> onData) {
-    return _source.observe((data) {
+    return source.observe((data) {
       final result = _convert(data);
       onData(result);
     });

--- a/lib/src/dart_observable/observables/observable_multicast.dart
+++ b/lib/src/dart_observable/observables/observable_multicast.dart
@@ -2,22 +2,21 @@
 import 'package:meta/meta.dart';
 import 'package:disposal/disposal.dart';
 
-import 'observable.dart';
-import 'observation.dart';
 import '../observers/observer.dart';
 import '../subjects/subject.dart';
 import '../subjects/publisher.dart';
+import 'base_observable.dart';
+import 'observation.dart';
 
 @internal
-class ObservableMulticast<T> implements Observable<T> {
+class ObservableMulticast<T> extends PipeObservable<T, T> {
 
   ObservableMulticast({
     required this.createSubject,
-    required this.source,
+    required super.source,
   }): shared = SharedBetweenObservations<T>();
 
   final Subject<T> Function()? createSubject;
-  final Observable<T> source;
 
   final SharedBetweenObservations<T> shared;
 

--- a/lib/src/dart_observable/observables/observable_skip.dart
+++ b/lib/src/dart_observable/observables/observable_skip.dart
@@ -2,20 +2,19 @@
 import 'package:meta/meta.dart';
 import 'package:disposal/disposal.dart';
 
-import 'observable.dart';
-import 'observation.dart';
 import '../observers/observer.dart';
+import 'base_observable.dart';
+import 'observation.dart';
 
 @internal
-class ObservableSkip<T> implements Observable<T> {
+class ObservableSkip<T> extends PipeObservable<T, T> {
 
   const ObservableSkip({
     required this.n,
-    required this.source,
+    required super.source,
   });
 
   final int n;
-  final Observable<T> source;
 
   @override
   Disposable observe(OnData<T> onData) {

--- a/lib/src/dart_observable/observables/observable_where.dart
+++ b/lib/src/dart_observable/observables/observable_where.dart
@@ -3,19 +3,17 @@ import 'package:meta/meta.dart';
 import 'package:disposal/disposal.dart';
 
 import '../observers/observer.dart';
-import 'observable.dart';
+import 'base_observable.dart';
 
 @internal
-class ObservableWhere<T> implements Observable<T> {
+class ObservableWhere<T> extends PipeObservable<T, T> {
 
   const ObservableWhere({
     required bool Function(T) test,
-    required Observable<T> source,
-  }): _test = test,
-    _source = source;
+    required super.source,
+  }): _test = test;
 
   final bool Function(T) _test;
-  final Observable<T> _source;
 
   @override
   Disposable observe(OnData<T> onData) {
@@ -24,6 +22,6 @@ class ObservableWhere<T> implements Observable<T> {
         onData(data);
       }
     }
-    return _source.observe(newOnData);
+    return source.observe(newOnData);
   }
 }


### PR DESCRIPTION
## Introduce `PipeObservable`

`PipeObservable` transform an input observable (the source) to an output observable (itself).

```dart
abstract class PipeObservable<T, R> implements Observable<R> {

  const PipeObservable({
    required this.source,
  });

  final Observable<T> source;
}
```

Example:

```dart
class ObservableMap<T, R> extends PipeObservable<T, R> {
  
  const ObservableMap({
    required this.convert,
    required super.source,
  });

  final R Function(T) convert;

  @override
  Disposable observe(OnData<R> onData) { ... }
}
```

`ObservableMap<T, R>` is a `PipeObservable`, since it transform an input `Observable<T>` to an output `Observable<R>`.