### PR TITLE
refactor - intorduce observable `MultiSourcePipeObservable`

### DIFF
--- a/lib/dart_scope.dart
+++ b/lib/dart_scope.dart
@@ -14,6 +14,7 @@ export 'src/dart_observable/dart_observable.dart'
     ObservableAsStatesX,
     LatestStateNotReplayError,
     PipeObservable,
+    MultiSourcePipeObservable,
     Observe,
     Observable,
     ObservableX,

--- a/lib/src/dart_observable/dart_observable.dart
+++ b/lib/src/dart_observable/dart_observable.dart
@@ -24,7 +24,8 @@ export 'errors/latest_state_not_replay_error.dart'
     LatestStateNotReplayError;
 export 'observables/base_observable.dart'
   show
-    PipeObservable;
+    PipeObservable,
+    MultiSourcePipeObservable;
 export 'observables/observable.dart'
   show
     Observe,

--- a/lib/src/dart_observable/observables/base_observable.dart
+++ b/lib/src/dart_observable/observables/base_observable.dart
@@ -49,11 +49,52 @@ abstract class PipeObservable<T, R> implements Observable<R> {
   final Observable<T> source;
 }
 
+/// `MultiSourcePipeObservable` is a pipeline that transform multiple input
+/// observables to an output observable.
+/// 
+/// The multiple input observables is a list of source,
+/// each source implements `Observable<T>`,
+/// and the output observable is itself that implements `Observable<R>`.
+/// 
+/// ```dart
+/// abstract class MultiSourcePipeObservable<T, R> implements Observable<R> {
+///
+///   const MultiSourcePipeObservable({
+///     required this.sources,
+///   });
+/// 
+///   final List<Observable<T>> sources; 
+/// }
+/// ```
+/// 
+/// Example:
+/// 
+/// ```dart
+/// class ObservableCombine<T, R> extends MultiSourcePipeObservable<T, R> {
+/// 
+///   const ObservableCombine({
+///     required super.sources,
+///     required this.combiner,
+///   });
+/// 
+///   final R Function(List<T> items) combiner;
+/// 
+///   @override
+///   Disposable observe(OnData<R> onData) {  ... }
+/// }
+/// ```
+/// 
+/// `ObservableCombine<T, R>` is a `MultiSourcePipeObservable`, 
+/// since it transform multiple input `Observable<T>` 
+/// to an output `Observable<R>`.
+/// 
 abstract class MultiSourcePipeObservable<T, R> implements Observable<R> {
 
+  /// Create a `MultiSourcePipeObservable` with sources.
   const MultiSourcePipeObservable({
     required this.sources,
   });
-  
+
+  /// The input observables
   final List<Observable<T>> sources; 
 }

--- a/lib/src/dart_observable/observables/base_observable.dart
+++ b/lib/src/dart_observable/observables/base_observable.dart
@@ -48,3 +48,12 @@ abstract class PipeObservable<T, R> implements Observable<R> {
   /// The input observable
   final Observable<T> source;
 }
+
+abstract class MultiSourcePipeObservable<T, R> implements Observable<R> {
+
+  const MultiSourcePipeObservable({
+    required this.sources,
+  });
+  
+  final List<Observable<T>> sources; 
+}

--- a/lib/src/dart_observable/observables/observable_combine.dart
+++ b/lib/src/dart_observable/observables/observable_combine.dart
@@ -3,18 +3,18 @@ import 'package:meta/meta.dart';
 import 'package:disposal/disposal.dart';
 
 import '../observers/observer.dart';
+import 'base_observable.dart';
 import 'observable.dart';
 import 'observation.dart';
 
 @internal
-class ObservableCombine<T, R> implements Observable<R> {
+class ObservableCombine<T, R> extends MultiSourcePipeObservable<T, R> {
 
   const ObservableCombine({
-    required this.sources,
+    required super.sources,
     required this.combiner,
   });
 
-  final List<Observable<T>> sources;
   final R Function(List<T> items) combiner;
 
   @override


### PR DESCRIPTION
## MultiSourcePipeObservable
`MultiSourcePipeObservable` is a pipeline that transform multiple input observables to an output observable.

The multiple input observables is a list of source, each source implements `Observable<T>`,
and the output observable is itself that implements `Observable<R>`.

```dart
abstract class MultiSourcePipeObservable<T, R> implements Observable<R> {

  const MultiSourcePipeObservable({
    required this.sources,
  });

  final List<Observable<T>> sources; 
}
```

Example:

```dart
class ObservableCombine<T, R> extends MultiSourcePipeObservable<T, R> {

  const ObservableCombine({
    required super.sources,
    required this.combiner,
  });

  final R Function(List<T> items) combiner;

  @override
  Disposable observe(OnData<R> onData) {  ... }
}
```

`ObservableCombine<T, R>` is a `MultiSourcePipeObservable`,  since it transform multiple input `Observable<T>` to an output `Observable<R>`.
