### PR TITLE
feature - add observable `InstanceAsObservable`

### DIFF
--- a/lib/dart_scope.dart
+++ b/lib/dart_scope.dart
@@ -15,6 +15,7 @@ export 'src/dart_observable/dart_observable.dart'
     LatestStateNotReplayError,
     PipeObservable,
     MultiSourcePipeObservable,
+    InstanceAsObservable,
     Observe,
     Observable,
     ObservableX,

--- a/lib/src/dart_observable/dart_observable.dart
+++ b/lib/src/dart_observable/dart_observable.dart
@@ -26,6 +26,9 @@ export 'observables/base_observable.dart'
   show
     PipeObservable,
     MultiSourcePipeObservable;
+export 'observables/instance_as_observable.dart'
+  show
+    InstanceAsObservable;
 export 'observables/observable.dart'
   show
     Observe,

--- a/lib/src/dart_observable/observables/instance_as_observable.dart
+++ b/lib/src/dart_observable/observables/instance_as_observable.dart
@@ -1,0 +1,75 @@
+
+import 'observable.dart';
+
+/// `InstanceAsObservable` provide an unified way to turn an instance 
+/// to an observable.
+/// 
+/// ```dart
+/// abstract class InstanceAsObservable<T, R> implements Observable<R> {
+///   
+///   const InstanceAsObservable(this.instance);
+/// 
+///   final T instance;
+/// }
+/// ```
+/// 
+/// Example - `ValueNotifierAsObservable`:
+/// 
+/// ```dart
+/// class ValueNotifierAsObservable<T extends ValueNotifier<R>, R> 
+///   extends InstanceAsObservable<T, R> {
+///   
+///   const ValueNotifierAsObservable(super.instance);
+///   
+///   @override
+///   Disposable observe(OnData<R> onData) {
+/// 
+///     onData(instance.value);
+/// 
+///     void listener() => onData(instance.value);
+/// 
+///     instance.addListener(listener);
+/// 
+///     return Disposable(() {
+///       instance.removeListener(listener);
+///     });
+///   }
+/// }
+/// ```
+/// 
+/// `ValueNotifierAsObservable` turns a `ValueNotifier<R>` to an `Observable<R>`:
+/// 
+/// ```dart
+/// class Counter extends ValueNotifier<int> {
+///   Counter(): super(0);
+///   void increment() => value += 1;
+/// }
+/// 
+/// void main() {
+///   final counter = Counter();
+///   final Observable<int> observable = ValueNotifierAsObservable(counter);
+///   final observation = observable.observe((data) {
+///     print('onData: $data');
+///   }); 
+///   counter.increment();
+///   counter.increment();
+///   observation.dispose();
+/// }
+/// ```
+/// 
+/// Prints:
+///
+/// ```
+/// onData: 0
+/// onData: 1
+/// onData: 2
+/// ``` 
+/// 
+abstract class InstanceAsObservable<T, R> implements Observable<R> {
+  
+  /// Create `InstanceAsObservable` with instance.
+  const InstanceAsObservable(this.instance);
+
+  /// The referenced instance.
+  final T instance;
+}

--- a/test/dart_observable/dart_observable_test.dart
+++ b/test/dart_observable/dart_observable_test.dart
@@ -10,6 +10,7 @@ import 'states/states_from_test.dart' as states_from_test;
 import 'states/states_map_test.dart' as states_map_test;
 import 'states/states_convert_test.dart' as states_convert_test;
 import 'states/states_skip_test.dart' as states_skip_test;
+import 'observables/instance_as_observable_test.dart' as instance_as_observable_test;
 import 'observables/observable_cast_test.dart' as observable_cast_test;
 import 'observables/observable_combine_test.dart' as observable_combine_test;
 import 'observables/observable_default_constructor_test.dart' as observable_default_constructor_test;
@@ -40,6 +41,7 @@ void main() {
   states_map_test.main();
   states_convert_test.main();
   states_skip_test.main();
+  instance_as_observable_test.main();
   observable_cast_test.main();
   observable_combine_test.main();
   observable_default_constructor_test.main();

--- a/test/dart_observable/observables/instance_as_observable_test.dart
+++ b/test/dart_observable/observables/instance_as_observable_test.dart
@@ -1,0 +1,26 @@
+
+import 'package:test/test.dart';
+import 'package:dart_scope/dart_scope.dart';
+
+void main() {
+
+  test('`InstanceAsObservable` common', () {
+
+    final stream = Stream.fromIterable([0, 1, 2]);
+    final observable = _StreamAsObservable(stream);
+
+    final isIdentical = identical(stream, observable.instance);
+
+    expect(isIdentical, true);
+  });
+}
+
+class _StreamAsObservable<T> extends InstanceAsObservable<Stream<T>, T> {
+
+  _StreamAsObservable(super.instance);
+
+  @override
+  Disposable observe(OnData<T> onData) {
+    throw UnimplementedError();
+  }
+}


### PR DESCRIPTION
## InstanceAsObservable
`InstanceAsObservable` provide an unified way to turn an instance to an observable.

```dart
abstract class InstanceAsObservable<T, R> implements Observable<R> {
  
  const InstanceAsObservable(this.instance);

  final T instance;
}
```

### Example1 - `StreamAsObservable`:

```dart
class StreamAsObservable<R> extends InstanceAsObservable<Stream<R>, R> {
  
  const StreamAsObservable(super.instance);

  @override
  Disposable observe(OnData<R> onData) {
    final subscription = instance.listen(onData);
    return Disposable(subscription.cancel);
  }
}
```

`StreamAsObservable` turns a `Stream<R>` to an `Observable<R>`:

```dart
void main() async {
  final Stream<int> stream = Stream.fromIterable([0, 1, 2]);
  final Observable<int> observable = StreamAsObservable(stream);
  final observation = observable.observe((data) {
    print('onData: $data');
  });
  await Future(() {});
  observation.dispose();
}
```

Prints:

```
onData: 0
onData: 1
onData: 2
```

### Example2 - `ValueNotifierAsObservable`:

```dart
class ValueNotifierAsObservable<T extends ValueNotifier<R>, R> 
  extends InstanceAsObservable<T, R> {
  
  const ValueNotifierAsObservable(super.instance);
  
  @override
  Disposable observe(OnData<R> onData) {

    onData(instance.value);

    void listener() => onData(instance.value);

    instance.addListener(listener);

    return Disposable(() {
      instance.removeListener(listener);
    });
  }
}
```

`ValueNotifierAsObservable` turns a `ValueNotifier<R>` to an `Observable<R>`:

```dart
class Counter extends ValueNotifier<int> {
  Counter(): super(0);
  void increment() => value += 1;
}

void main() {
  final counter = Counter();
  final Observable<int> observable = ValueNotifierAsObservable(counter);
  final observation = observable.observe((data) {
    print('onData: $data');
  }); 
  counter.increment();
  counter.increment();
  observation.dispose();
}
```

Prints:
```
onData: 0
onData: 1
onData: 2
``` 

### Example3 - `CubitAsObservable`:

```dart
class CubitAsObservable<T extends Cubit<R>, R> extends InstanceAsObservable<T, R> {
  
  const CubitAsObservable(super.instance);

  @override
  Disposable observe(OnData<R> onData) {
    onData(instance.state);
    final subscription = instance.stream.listen(onData);
    return Disposable(subscription.cancel);
  }
}
```

`CubitAsObservable` turns a `Cubit<R>` to an `Observable<R>`:

```dart
class CounterCubit extends Cubit<int> {
  CounterCubit() : super(0);
  void increment() => emit(state + 1);
}

void main() async {
  final cubit = CounterCubit();
  final Observable<int> observable = CubitAsObservable(cubit);
  final observation = observable.observe((data) {
    print('onData: $data');
  });
  cubit.increment();
  cubit.increment();

  await Future(() {});
  observation.dispose();
}
```

Prints:

```
onData: 0
onData: 1
onData: 2
```

`Cubit` is a state manager form `bloc` package,  
See https://pub.dev/documentation/bloc/latest/bloc/Cubit-class.html.