### PR TITLE
fix - handle self disposal while process data

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -10,7 +10,7 @@ builders:
   _test_builder:
     import: "test/test_gen/test_builder.dart"
     builder_factories: ["testBuilder"]
-    build_extensions: { ".dart": [".g.dart"] }
+    build_extensions: { ".dart": [".g.part"] }
     auto_apply: dependents
     build_to: cache
     applies_builders: ["source_gen|combining_builder"]

--- a/lib/src/dart_observable/subjects/basic_subject.dart
+++ b/lib/src/dart_observable/subjects/basic_subject.dart
@@ -25,7 +25,7 @@ class BasicSubject<T> implements Subject<T> {
     if (_map.isEmpty) {
       return;
     }
-    for (final onData in _map.values) {
+    for (final onData in _map.values.toList()) {
       onData(data);
     }
   }


### PR DESCRIPTION
# Why

As code shown:

```dart
    for (final onData in _map.values) {
      onData(data);
    }
```

While processing data, it may mutate the `_map` during iteration which may throw error.

# How to fix it

We may create a new iteration list to prevent the error:

```diff
-    for (final onData in _map.values) {
+    for (final onData in _map.values.toList()) {
```



